### PR TITLE
This change fixes some sporadic 502 responses of traefic on backend

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
@@ -1,6 +1,6 @@
 version: '3.3'
 services:
   proxy:
-    image: traefik:v1.6
+    image: traefik:v1.7.9-alpine
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
@@ -1,6 +1,6 @@
 version: '3.3'
 services:
   proxy:
-    image: traefik:v1.7.9-alpine
+    image: traefik:v1.7
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
The ref ticket: https://github.com/containous/traefik/issues/3237

And my comment:

Looks like I had the same issue.
Using traefik in a Swarm.
I have a backend service configured as

backend:
    labels:
      - traefik.frontend.rule=PathPrefixStrip:/api/

So the call to localhost/api/cities/all was failing on each second request (502).

Updated my treafik docker container form v1.6 to the latest one 1.7.9-alpine rebuild everything and now seems everything is working